### PR TITLE
Added parameters to ensure same hash output

### DIFF
--- a/extension/src/hashpass/__tests__/test.route.ts
+++ b/extension/src/hashpass/__tests__/test.route.ts
@@ -14,11 +14,24 @@ describe('POST function', () => {
     });
 
     jest.spyOn(argon2, 'hash').mockResolvedValue('mocked_hash_value');
-    
+
     const response = await POST(mockRequest);
     const json = await response.json();
 
-    expect(argon2.hash).toHaveBeenCalledWith('test_password');
+    const actualCall = (argon2.hash as jest.Mock).mock.calls[0][1];
+
+    if (Buffer.isBuffer(actualCall.salt)) {
+      actualCall.salt = { data: Array.from(actualCall.salt), type: 'Buffer' };
+    }
+
+    expect(actualCall).toEqual({
+      memoryCost: 65536,
+      parallelism: 1,
+      salt: { data: [109, 121, 45, 115, 116, 97, 116, 105, 99, 45, 115, 97, 108, 116], type: 'Buffer' },
+      timeCost: 2,
+      type: 2,
+    });
+
     expect(json).toEqual({ hash: 'mocked_hash_value' });
   });
 });

--- a/extension/src/hashpass/app/api/hash/route.ts
+++ b/extension/src/hashpass/app/api/hash/route.ts
@@ -4,7 +4,13 @@ import argon2 from 'argon2';
 export async function POST(req: NextRequest) {
   try {
     const { textToHash } = await req.json();
-    const hash = await argon2.hash(textToHash);
+    const hash = await argon2.hash(textToHash, {
+      salt: Buffer.from("my-static-salt", "utf8"),
+      type: argon2.argon2id,
+      timeCost: 2,
+      memoryCost: 65536,
+      parallelism: 1,
+    });
     return NextResponse.json({ hash });
   } catch (err) {
     if (err instanceof Error) {


### PR DESCRIPTION
## Issue Reference  
<!-- Link to the GitHub issue this PR resolves. Use the format `#<issue-number>` -->  
#24 
## Description of the Issue  
<!-- Provide a clear and concise description of the issue that this PR addresses. -->
Argon2 was not hashing to the same output for same inputs. That has been resolved by adding parameters to the hash function.
## Expected Output / Behavior  
<!-- Describe what the expected outcome of this PR should be. Include any relevant screenshots or examples if applicable. -->
Hash should output to the same value for any same input.

## Additional Notes  
<!-- Add any extra notes, considerations, or potential future improvements. -->
