### PR TITLE
76 fix cors issue with hash api

### DIFF
--- a/extension/src/hashpass/app/security_components/components/password_generator.tsx
+++ b/extension/src/hashpass/app/security_components/components/password_generator.tsx
@@ -27,7 +27,7 @@ export default function PasswordGenerator() {
     const site_domain = "amazon.com"
 
     const [inputValue, setInputValue] = useState('');
-    //const [strong_password, setStrongPasswordText] = useState('');
+    const [strong_password, setStrongPasswordText] = useState('');
 
     const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setInputValue(e.target.value);
@@ -58,7 +58,7 @@ export default function PasswordGenerator() {
         console.log(fullHash)
         console.log(extractedHash)
 
-        //setStrongPasswordText(extractedHash);
+        setStrongPasswordText(extractedHash);
 
     
     };
@@ -77,7 +77,7 @@ export default function PasswordGenerator() {
         <button onClick={handleGeneratePassword}>Generate Strong Password</button>
 
         <p>Current value: {inputValue}</p>
-        {/*strong_password && <p>Strong Password: {strong_password}</p>*/}
+        {strong_password && <p>Strong Password: {strong_password}</p>}
     </div>
 );
 }

--- a/extension/src/hashpass/app/security_components/tools/hashing_tool.tsx
+++ b/extension/src/hashpass/app/security_components/tools/hashing_tool.tsx
@@ -1,6 +1,6 @@
 export const hashText = async (text: string): Promise<string> => {
     try {
-        const response = await fetch('https://tbkegmgwccq5iiea4tbk5fvmma0tfeya.lambda-url.us-east-1.on.aws/', {
+        const response = await fetch('https://oawbglgv44.execute-api.us-east-1.amazonaws.com/dev/calc_hash', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ textToHash: text }),

--- a/extension/src/hashpass/public/dist/components.bundle.js
+++ b/extension/src/hashpass/public/dist/components.bundle.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 "use strict";
 var Components = (() => {
   var __create = Object.create;

--- a/extension/src/hashpass/public/dist/components.bundle.js
+++ b/extension/src/hashpass/public/dist/components.bundle.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 "use strict";
 var Components = (() => {
   var __create = Object.create;
@@ -21312,7 +21311,7 @@ var Components = (() => {
   // app/security_components/tools/hashing_tool.tsx
   var hashText = async (text) => {
     try {
-      const response = await fetch("https://tbkegmgwccq5iiea4tbk5fvmma0tfeya.lambda-url.us-east-1.on.aws/", {
+      const response = await fetch("https://oawbglgv44.execute-api.us-east-1.amazonaws.com/dev/calc_hash", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ textToHash: text })


### PR DESCRIPTION
## Issue Reference  
<!-- Link to the GitHub issue this PR resolves. Use the format `#<issue-number>` -->  
#76 
## Description of the Issue  
<!-- Provide a clear and concise description of the issue that this PR addresses. -->
Previously the hashing API was not able to be called on the browser due to CORS policies. Changed the CORS header via the aws cli tool
## Expected Output / Behavior  
<!-- Describe what the expected outcome of this PR should be. Include any relevant screenshots or examples if applicable. -->
Now hashing and encryption/decryption should work. calc_hash api works.

## Additional Notes  
<!-- Add any extra notes, considerations, or potential future improvements. -->
To test, go to a sign up page and generate a random password. If a random password is generated with no errors, it works.
